### PR TITLE
style: Menu 도메인 mealDate 날짜만 저장

### DIFF
--- a/src/main/java/semohan/owner/domain/menu/domain/Menu.java
+++ b/src/main/java/semohan/owner/domain/menu/domain/Menu.java
@@ -19,6 +19,7 @@ public class Menu {
     private long id;
 
     @NotNull
+    @Temporal(TemporalType.DATE)    // 시간 정보 없이 날짜만 저장
     private Date mealDate;
 
     @NotNull


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
main -> main

### 변경 사항
Menu 도메인의 mealDate를 손님 사이트와 동일하게 날짜만 저장하게 변경했습니다. 